### PR TITLE
Preventing  command line injection on exec command

### DIFF
--- a/Service/Downloader.php
+++ b/Service/Downloader.php
@@ -19,10 +19,12 @@ class Downloader
             }
         }
 
-        $url = escapeshellcmd($url);
-
         if (is_writable($path)) {
             $outputFile = $path . $destinationFileName;
+
+            $url = escapeshellcmd($url);
+            $outputFile = escapeshellcmd($outputFile);
+
             $cmd = "wget -c -q \"$url\" -O $outputFile";
             exec($cmd);
             if (0 == filesize($outputFile)) {

--- a/Service/Downloader.php
+++ b/Service/Downloader.php
@@ -19,6 +19,8 @@ class Downloader
             }
         }
 
+        $url = escapeshellcmd($url);
+
         if (is_writable($path)) {
             $outputFile = $path . $destinationFileName;
             $cmd = "wget -c -q \"$url\" -O $outputFile";
@@ -42,5 +44,6 @@ class Downloader
     {
         return is_writable(dirname($path));
     }
+
 
 }

--- a/Tests/Service/DownloaderTest.php
+++ b/Tests/Service/DownloaderTest.php
@@ -110,4 +110,23 @@ class DownloaderTest extends \PHPUnit_Framework_TestCase
         rmdir($path);
     }
 
+    /**
+     * Fix for command line injection on exec
+     */
+    public function testCmdHacking()
+    {
+        $dir = "/tmp/supu";
+        @rmdir($dir);
+        $injectedCode = 'mkdir ' . $dir;
+
+        $downloadUrl = '"; ' . $injectedCode . '; "';
+        $path = '/tmp/test/';
+        $filename = 'downloadedFile.pl';
+        try {
+            $this->downloader->downloadFile($downloadUrl, $path, $filename);
+        } catch(FileException $e) {
+            $this->assertFalse(is_dir($dir));
+        }
+
+    }
 }


### PR DESCRIPTION
The exec function should be replaced for something less dangerous, but, at least this is a simple temporary fix.
